### PR TITLE
create news article page route

### DIFF
--- a/client/src/RouteSwitch.tsx
+++ b/client/src/RouteSwitch.tsx
@@ -5,6 +5,7 @@ import { Home } from "./routes/Home";
 import { Navbar } from "./components/Navbar/Navbar";
 import { Welcome } from "./routes/Welcome";
 import { ThemeContext } from "./context/ThemeContext";
+import { News } from "./routes/News";
 
 export const RouteSwitch = () => {
   return (
@@ -14,6 +15,7 @@ export const RouteSwitch = () => {
         <Routes>
           <Route path="/crypto-exchange/" element={<Welcome />} />
           <Route path="/crypto-exchange/home" element={<Home />} />
+          <Route path="/crypto-exchange/news" element={<News />} />
           <Route
             path="/crypto-exchange/login"
             element={

--- a/client/src/components/Home/NewsArticleCard.tsx
+++ b/client/src/components/Home/NewsArticleCard.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import {
+  Card,
+  CardActions,
+  CardContent,
+  CardMedia,
+  Button,
+  Typography,
+} from "@mui/material/";
+import { NewsArticle } from "../../data/global.models";
+
+interface Props {
+  article: NewsArticle;
+}
+
+const style = {
+  height: "250px",
+  display: "flex",
+  flexDirection: "column",
+  overflow: "unset",
+};
+
+export const NewsArticleCard: React.FC<Props> = ({ article }) => {
+  return (
+    <Card sx={style} className="animate__animated animate__zoomIn">
+      <CardMedia
+        component="img"
+        alt="article"
+        image={article.image_url}
+        sx={{
+          maxHeight: "100px",
+          overflow: "hidden",
+          objectPosition: "0 -60px",
+        }}
+      />
+
+      <CardContent sx={{ overflow: "scroll", padding: "8px" }}>
+        <Typography gutterBottom variant="body1" component="div">
+          {article.title}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          {article.description}
+        </Typography>
+      </CardContent>
+
+      <CardActions sx={{ padding: "0 10px" }}>
+        <Button
+          size="small"
+          onClick={() => window.open(`${article.link}`, "_blank")}
+        >
+          Visit Source
+        </Button>
+      </CardActions>
+    </Card>
+  );
+};

--- a/client/src/components/Home/NewsArticleCard.tsx
+++ b/client/src/components/Home/NewsArticleCard.tsx
@@ -14,10 +14,12 @@ interface Props {
 }
 
 const style = {
+  width: "300px",
   height: "250px",
   display: "flex",
   flexDirection: "column",
   overflow: "unset",
+  boxShadow: "rgba(100, 100, 111, 0.2) 0px 7px 29px 0px",
 };
 
 export const NewsArticleCard: React.FC<Props> = ({ article }) => {

--- a/client/src/components/Navbar/Navbar.tsx
+++ b/client/src/components/Navbar/Navbar.tsx
@@ -110,6 +110,12 @@ export const Navbar = () => {
               open={Boolean(anchorElUser)}
               onClose={handleCloseUserMenu}
             >
+              {user && (
+                <MenuItem onClick={handleCloseUserMenu} sx={style}>
+                  <ProfileDrawer />
+                </MenuItem>
+              )}
+
               {/* Dynamically Rendered Navbar Options */}
               {curLocation === "home" ? null : (
                 <Link to="/crypto-exchange/home">
@@ -119,10 +125,12 @@ export const Navbar = () => {
                 </Link>
               )}
 
-              {user && (
-                <MenuItem onClick={handleCloseUserMenu} sx={style}>
-                  <ProfileDrawer />
-                </MenuItem>
+              {curLocation === "news" ? null : (
+                <Link to="/crypto-exchange/news">
+                  <MenuItem onClick={handleCloseUserMenu} sx={style}>
+                    News
+                  </MenuItem>
+                </Link>
               )}
 
               {curLocation === "" ? null : (

--- a/client/src/context/GlobalCryptoContext.tsx
+++ b/client/src/context/GlobalCryptoContext.tsx
@@ -25,6 +25,7 @@ export const useGlobalContext = () => {
 export const GlobalCryptoProvider: ContextProviderComponent = ({
   children,
 }) => {
+  // Utilizes our custom hooks that fetch our application data
   const [user, setUser, token, setToken] = useUserAuth();
   const [cryptos, setCryptos, serverOffline] = useFetchPosts();
   const newsArticles = useFetchNews();
@@ -44,10 +45,6 @@ export const GlobalCryptoProvider: ContextProviderComponent = ({
     }, 5000);
   };
 
-  useEffect(() => {
-    console.log(newsArticles);
-  }, [newsArticles]);
-
   return (
     <CryptoContext.Provider
       value={{
@@ -59,6 +56,7 @@ export const GlobalCryptoProvider: ContextProviderComponent = ({
         setToken,
         togglePageLoading,
         handleBannerMessage,
+        newsArticles,
       }}
     >
       {/* Will populate all nested children components */}

--- a/client/src/context/GlobalCryptoContext.tsx
+++ b/client/src/context/GlobalCryptoContext.tsx
@@ -1,4 +1,4 @@
-import { useContext, createContext, useState } from "react";
+import { useContext, createContext, useState, useEffect } from "react";
 import { PopupBanner } from "../components/PopupBanner";
 import { LoadingUx } from "../components/LoadingUx";
 import {
@@ -9,6 +9,7 @@ import {
 } from "./context.models";
 import { useUserAuth } from "../hooks/useUserAuth";
 import { useFetchPosts } from "../hooks/useFetchPosts";
+import { useFetchNews } from "../hooks/useFetchNews";
 
 // Create context, and export custom hook that can extract our context values in different components.
 const CryptoContext = createContext<ContextInterface | null>(null);
@@ -26,6 +27,8 @@ export const GlobalCryptoProvider: ContextProviderComponent = ({
 }) => {
   const [user, setUser, token, setToken] = useUserAuth();
   const [cryptos, setCryptos, serverOffline] = useFetchPosts();
+  const newsArticles = useFetchNews();
+
   const [pageLoading, setPageLoading] = useState<boolean>(false);
   const [showPopupBanner, setShowPopupBanner] = useState<BannerMessage>({
     show: false,
@@ -40,6 +43,10 @@ export const GlobalCryptoProvider: ContextProviderComponent = ({
       setShowPopupBanner({ show: false, message: "" });
     }, 5000);
   };
+
+  useEffect(() => {
+    console.log(newsArticles);
+  }, [newsArticles]);
 
   return (
     <CryptoContext.Provider

--- a/client/src/context/context.models.ts
+++ b/client/src/context/context.models.ts
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { Crypto, User } from "../data/global.models";
+import { Crypto, NewsArticle, User } from "../data/global.models";
 
 // Theme Context
 export type ThemeProviderInterface = ({
@@ -20,6 +20,7 @@ export interface ContextInterface {
   setToken: React.Dispatch<React.SetStateAction<string | null>>;
   togglePageLoading: () => void;
   handleBannerMessage: (type: "success" | "error", message: string) => void;
+  newsArticles: NewsArticle[];
 }
 
 export interface BannerMessage {

--- a/client/src/data/api.models.ts
+++ b/client/src/data/api.models.ts
@@ -1,4 +1,4 @@
-import { User, Account, Crypto } from "./global.models";
+import { User, Account, Crypto, NewsArticle } from "./global.models";
 
 export type UserPromiseFunction = () => Promise<User>;
 
@@ -11,6 +11,8 @@ export type UpdateUserImageFunction = (
 export type AccessAccountFunction = (account: Account) => Promise<string>;
 
 export type GetCryptoFunction = (name?: string) => Promise<Crypto[]>;
+
+export type GetNewsArticlesFunction = () => Promise<NewsArticle[]>;
 
 export type UpdateCryptoFunction = (name?: string) => Promise<Crypto>;
 

--- a/client/src/data/api.ts
+++ b/client/src/data/api.ts
@@ -7,6 +7,7 @@ import {
   GetCryptoFunction,
   UpdateNameFunction,
   UpdateUserImageFunction,
+  GetNewsArticlesFunction,
 } from "./api.models";
 import axios from "axios";
 import config from "./config.json";
@@ -129,6 +130,16 @@ export const bookmarkCrypto: bookmarkCryptoFunction = async (name) => {
     return Promise.resolve(response.data.user);
   } catch (error) {
     console.log(error);
+    return Promise.reject(error);
+  }
+};
+
+export const getNewsArticles: GetNewsArticlesFunction = async () => {
+  try {
+    const response = await axios.get(`${config.api}/news/`);
+
+    return Promise.resolve(response.data.articles);
+  } catch (error) {
     return Promise.reject(error);
   }
 };

--- a/client/src/data/global.models.ts
+++ b/client/src/data/global.models.ts
@@ -28,6 +28,17 @@ export interface Crypto {
   };
 }
 
+export interface NewsArticle {
+  title: string;
+  link: string;
+  creator: [];
+  description: string;
+  content: string;
+  pubDate: Date;
+  image_url: string;
+  dateAdded: Date;
+}
+
 export interface Account {
   username: string;
   password: string;

--- a/client/src/hooks/useFetchNews.ts
+++ b/client/src/hooks/useFetchNews.ts
@@ -1,0 +1,22 @@
+import { useState, useEffect } from "react";
+import { getNewsArticles } from "../data/api";
+import { NewsArticle } from "../data/global.models";
+
+export const useFetchNews = () => {
+  const [newsArticles, setNewsArticles] = useState<NewsArticle[]>([]);
+
+  useEffect(() => {
+    const fetchNews = async () => {
+      try {
+        const articles = await getNewsArticles();
+        setNewsArticles(articles);
+      } catch (error) {
+        console.log(error);
+      }
+    };
+
+    fetchNews();
+  }, []);
+
+  return newsArticles;
+};

--- a/client/src/routes/Home.tsx
+++ b/client/src/routes/Home.tsx
@@ -43,13 +43,14 @@ const CryptosWrapper = styled.div`
 `;
 const NewsArticlesWrapper = styled.div`
   display: none;
+  padding: 0 5px;
   @media (min-width: 1000px) {
     width: 300px;
     height: 90vh;
 
     overflow: scroll;
     /* outline: auto; */
-    box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
+    /* box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px; */
     margin-right: 5px;
 
     display: flex;

--- a/client/src/routes/Home.tsx
+++ b/client/src/routes/Home.tsx
@@ -12,6 +12,8 @@ import Pagination from "@mui/material/Pagination";
 import { ToolBar } from "../components/Home/ToolBar/ToolBar";
 import styled from "styled-components";
 import { NewsArticleCard } from "../components/Home/NewsArticleCard";
+import OnlinePredictionIcon from "@mui/icons-material/OnlinePrediction";
+import { Typography } from "@mui/material";
 
 const HomeWrapper = styled.div`
   min-height: calc(100vh - 64px);
@@ -45,9 +47,11 @@ const NewsArticlesWrapper = styled.div`
   @media (min-width: 1000px) {
     width: 300px;
     height: 90vh;
-    overflow: scroll;
 
+    overflow: scroll;
     /* outline: auto; */
+    box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
+    margin-right: 5px;
 
     display: flex;
     flex-direction: column;
@@ -68,10 +72,14 @@ export const Home = () => {
 
   const [page, setPage] = useState(1);
   let ranges = [
-    [0, 9],
-    [9, 18],
-    [18, 27],
-    [27, 36],
+    [0, 4],
+    [4, 8],
+    [8, 12],
+    [12, 16],
+    [16, 20],
+    [20, 24],
+    [24, 28],
+    [28, 32],
   ];
   const theme = useTheme();
 
@@ -133,7 +141,7 @@ export const Home = () => {
             })}
         </div>
         <Pagination
-          count={Math.ceil(organizedCryptos.length / 9)}
+          count={Math.ceil(organizedCryptos.length / 4)}
           page={page}
           onChange={(e, value) => setPage(value)}
           sx={{ flex: 1, padding: "10px 0" }}
@@ -141,9 +149,31 @@ export const Home = () => {
       </CryptosWrapper>
 
       <NewsArticlesWrapper>
-        <p style={{ textAlign: "center", paddingTop: "25px" }}>
-          {newsArticles.length ? "Trending News" : ""}
-        </p>
+        <span style={{ textAlign: "center", paddingTop: "25px" }}>
+          {newsArticles.length ? (
+            <span
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: "10px",
+                color: theme.palette.mode === "light" ? "black" : "white",
+              }}
+            >
+              <OnlinePredictionIcon
+                color="success"
+                className="animate__animated animate__fadeIn animate__infinite animate__slower"
+              />
+              Trending News
+              <OnlinePredictionIcon
+                color="success"
+                className="animate__animated animate__fadeIn animate__infinite animate__slower"
+              />
+            </span>
+          ) : (
+            ""
+          )}
+        </span>
         {newsArticles.map((article, i) => {
           return <NewsArticleCard key={i} article={article} />;
         })}

--- a/client/src/routes/Home.tsx
+++ b/client/src/routes/Home.tsx
@@ -13,7 +13,6 @@ import { ToolBar } from "../components/Home/ToolBar/ToolBar";
 import styled from "styled-components";
 import { NewsArticleCard } from "../components/Home/NewsArticleCard";
 import OnlinePredictionIcon from "@mui/icons-material/OnlinePrediction";
-import { Typography } from "@mui/material";
 
 const HomeWrapper = styled.div`
   min-height: calc(100vh - 64px);

--- a/client/src/routes/Home.tsx
+++ b/client/src/routes/Home.tsx
@@ -11,6 +11,7 @@ import { useTheme } from "@mui/material/styles";
 import Pagination from "@mui/material/Pagination";
 import { ToolBar } from "../components/Home/ToolBar/ToolBar";
 import styled from "styled-components";
+import { NewsArticleCard } from "../components/Home/NewsArticleCard";
 
 const HomeWrapper = styled.div`
   min-height: calc(100vh - 64px);
@@ -25,7 +26,6 @@ const HomeWrapper = styled.div`
 `;
 const CryptosWrapper = styled.div`
   flex: 1;
-  outline: auto;
 
   display: flex;
   flex-direction: column;
@@ -43,8 +43,15 @@ const CryptosWrapper = styled.div`
 const NewsArticlesWrapper = styled.div`
   display: none;
   @media (min-width: 1000px) {
-    display: block;
-    width: clamp(100px, 300px, 100vw);
+    width: 300px;
+    height: 90vh;
+    overflow: scroll;
+
+    /* outline: auto; */
+
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
   }
 `;
 
@@ -134,8 +141,11 @@ export const Home = () => {
       </CryptosWrapper>
 
       <NewsArticlesWrapper>
+        <p style={{ textAlign: "center", paddingTop: "25px" }}>
+          {newsArticles.length ? "Trending News" : ""}
+        </p>
         {newsArticles.map((article, i) => {
-          return <li key={i}>{article.title}</li>;
+          return <NewsArticleCard key={i} article={article} />;
         })}
       </NewsArticlesWrapper>
     </HomeWrapper>

--- a/client/src/routes/Home.tsx
+++ b/client/src/routes/Home.tsx
@@ -10,10 +10,53 @@ import { updateSingleCrypto } from "../data/api";
 import { useTheme } from "@mui/material/styles";
 import Pagination from "@mui/material/Pagination";
 import { ToolBar } from "../components/Home/ToolBar/ToolBar";
+import styled from "styled-components";
+
+const HomeWrapper = styled.div`
+  min-height: calc(100vh - 64px);
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  @media (min-width: 1000px) {
+    flex-direction: row;
+    align-items: stretch;
+  }
+`;
+const CryptosWrapper = styled.div`
+  flex: 1;
+  outline: auto;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .cryptosContainer {
+    flex: 8;
+
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-evenly;
+    gap: 10px;
+  }
+`;
+const NewsArticlesWrapper = styled.div`
+  display: none;
+  @media (min-width: 1000px) {
+    display: block;
+    width: clamp(100px, 300px, 100vw);
+  }
+`;
 
 export const Home = () => {
-  const { cryptos, user, togglePageLoading, setUser, handleBannerMessage } =
-    useGlobalContext();
+  const {
+    cryptos,
+    user,
+    togglePageLoading,
+    setUser,
+    handleBannerMessage,
+    newsArticles,
+  } = useGlobalContext();
   const [organizedCryptos, setOrganizedCryptos] = useState<Crypto[]>([]);
 
   const [page, setPage] = useState(1);
@@ -53,42 +96,48 @@ export const Home = () => {
   };
 
   return (
-    <div
-      className="Home"
+    <HomeWrapper
       style={{
         backgroundColor: `${determineThemeBackground(theme.palette.mode)}`,
       }}
     >
-      <ToolBar
-        user={user}
-        cryptos={cryptos}
-        organizedCryptos={organizedCryptos}
-        setOrganizedCryptos={setOrganizedCryptos}
-      />
+      <CryptosWrapper>
+        <ToolBar
+          user={user}
+          cryptos={cryptos}
+          organizedCryptos={organizedCryptos}
+          setOrganizedCryptos={setOrganizedCryptos}
+        />
+        <div className="cryptosContainer">
+          {organizedCryptos
+            .slice(ranges[page - 1][0], ranges[page - 1][1])
+            .map((crypto) => {
+              return (
+                <CryptoCard
+                  key={crypto.ticker}
+                  crypto={crypto}
+                  user={user}
+                  handleUpdateSingleCrypto={handleUpdateSingleCrypto}
+                  setUser={setUser}
+                  togglePageLoading={togglePageLoading}
+                  bookmarks={user ? user.bookmarks : []}
+                />
+              );
+            })}
+        </div>
+        <Pagination
+          count={Math.ceil(organizedCryptos.length / 9)}
+          page={page}
+          onChange={(e, value) => setPage(value)}
+          sx={{ flex: 1, padding: "10px 0" }}
+        />
+      </CryptosWrapper>
 
-      <div className="cryptosContainer">
-        {organizedCryptos
-          .slice(ranges[page - 1][0], ranges[page - 1][1])
-          .map((crypto) => {
-            return (
-              <CryptoCard
-                key={crypto.ticker}
-                crypto={crypto}
-                user={user}
-                handleUpdateSingleCrypto={handleUpdateSingleCrypto}
-                setUser={setUser}
-                togglePageLoading={togglePageLoading}
-                bookmarks={user ? user.bookmarks : []}
-              />
-            );
-          })}
-      </div>
-      <Pagination
-        count={Math.ceil(organizedCryptos.length / 9)}
-        page={page}
-        onChange={(e, value) => setPage(value)}
-        sx={{ flex: 1, padding: "10px 0" }}
-      />
-    </div>
+      <NewsArticlesWrapper>
+        {newsArticles.map((article, i) => {
+          return <li key={i}>{article.title}</li>;
+        })}
+      </NewsArticlesWrapper>
+    </HomeWrapper>
   );
 };

--- a/client/src/routes/News.tsx
+++ b/client/src/routes/News.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export const News = () => {
+  return <div>News</div>;
+};

--- a/client/src/routes/News.tsx
+++ b/client/src/routes/News.tsx
@@ -1,5 +1,49 @@
 import React from "react";
+import { useGlobalContext } from "../context/GlobalCryptoContext";
+import { NewsArticleCard } from "../components/Home/NewsArticleCard";
+import OnlinePredictionIcon from "@mui/icons-material/OnlinePrediction";
+import { useTheme } from "@mui/material";
+import styled from "styled-components";
+
+const NewsArticleWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
 
 export const News = () => {
-  return <div>News</div>;
+  const { newsArticles } = useGlobalContext();
+  const theme = useTheme();
+
+  return (
+    <NewsArticleWrapper>
+      <span style={{ textAlign: "center", paddingTop: "25px" }}>
+        {newsArticles.length ? (
+          <span
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: "10px",
+              color: theme.palette.mode === "light" ? "black" : "white",
+            }}
+          >
+            <OnlinePredictionIcon
+              color="success"
+              className="animate__animated animate__fadeIn animate__infinite animate__slower"
+            />
+            Trending News
+            <OnlinePredictionIcon
+              color="success"
+              className="animate__animated animate__fadeIn animate__infinite animate__slower"
+            />
+          </span>
+        ) : (
+          ""
+        )}
+      </span>
+      {newsArticles.map((article, i) => {
+        return <NewsArticleCard key={i} article={article} />;
+      })}
+    </NewsArticleWrapper>
+  );
 };

--- a/client/src/routes/News.tsx
+++ b/client/src/routes/News.tsx
@@ -8,6 +8,14 @@ import styled from "styled-components";
 const NewsArticleWrapper = styled.div`
   display: flex;
   flex-direction: column;
+  .newsArticlesContainer {
+    width: 100%;
+
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
 `;
 
 export const News = () => {
@@ -16,7 +24,7 @@ export const News = () => {
 
   return (
     <NewsArticleWrapper>
-      <span style={{ textAlign: "center", paddingTop: "25px" }}>
+      <span style={{ textAlign: "center", padding: "25px 0" }}>
         {newsArticles.length ? (
           <span
             style={{
@@ -41,9 +49,11 @@ export const News = () => {
           ""
         )}
       </span>
-      {newsArticles.map((article, i) => {
-        return <NewsArticleCard key={i} article={article} />;
-      })}
+      <div className="newsArticlesContainer">
+        {newsArticles.map((article, i) => {
+          return <NewsArticleCard key={i} article={article} />;
+        })}
+      </div>
     </NewsArticleWrapper>
   );
 };

--- a/client/src/styles/_home.scss
+++ b/client/src/styles/_home.scss
@@ -1,37 +1,17 @@
-.Home {
-  min-height: calc(100vh - 64px);
-
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-
-  .cryptosContainer {
-    flex: 8;
-    // min-height: calc(90vh - 150px);
-    width: clamp(340px, 1100px, 100vw);
+.CryptoCard {
+  min-width: 310px;
+  .priceHistoryChips {
+    padding-top: 5px;
 
     display: flex;
+    max-width: 300px;
     flex-wrap: wrap;
-    justify-content: space-evenly;
-    gap: 10px;
-
-    // Nested Component
-    .CryptoCard {
-      min-width: 310px;
-      .priceHistoryChips {
-        padding-top: 5px;
-
-        display: flex;
-        max-width: 300px;
-        flex-wrap: wrap;
-        gap: 5px;
-      }
-      .cryptoName {
-        max-width: 140px;
-        overflow: scroll;
-        white-space: nowrap;
-      }
-    }
+    gap: 5px;
+  }
+  .cryptoName {
+    max-width: 140px;
+    overflow: scroll;
+    white-space: nowrap;
   }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ npm start
 
 API server would need the following environments and variables provided to run successfully:
 
-- MONGO_DB, SECRET_STRING, CLOUDINARY_CLOUD, CLOUDINARY_API, CLOUDINARY_SECRET
+- MONGO_DB, SECRET_STRING, CLOUDINARY_CLOUD, CLOUDINARY_API, CLOUDINARY_SECRET, NEWSDATA_TOKEN
 
 #### To-Do's
 
@@ -59,3 +59,4 @@ API server would need the following environments and variables provided to run s
 > Bugs
 
 - Fix open spacing on bottom of page when cryptos are loading.
+- Have API respond with newsArticles from news endpoint, instead of articles, so we align close to the naming conventions used in our client and server


### PR DESCRIPTION
- create new route for news articles, and display all new articles there.
- create new tab on home page with news articles, when viewport is large enough to display cryptos and news articles side by side
- reduce the number of cryptos displayed per section, as we have filters, and search bar to look for specific cryptos 
- create styled components that wrap around the major sections of our homepage in orders to dynamically position them much more easier